### PR TITLE
[ENG-425] Fix: Product Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In your **`pom.xml`**:
     <dependency>
         <groupId>co.cookies.sdk</groupId>
         <artifactId>sdk-java</artifactId>
-        <version>v1.2021r1-beta1</version>
+        <version>v1.2021r1-beta2</version>
     </dependency>
 </dependencies>
 
@@ -46,7 +46,7 @@ In your **`pom.xml`**:
 Groovy syntax:
 ```groovy
 dependencies {
-    implementation 'co.cookies.sdk:sdk-java:v1.2021r1-beta1'
+    implementation 'co.cookies.sdk:sdk-java:v1.2021r1-beta2'
 }
 
 repositories {
@@ -59,7 +59,7 @@ repositories {
 Kotlin syntax:
 ```kotlin
 dependencies {
-    implementation("co.cookies.sdk.sdk-java:v1.2021r1-beta1")
+    implementation("co.cookies.sdk.sdk-java:v1.2021r1-beta2")
 }
 
 maven {
@@ -73,8 +73,8 @@ In your **`WORKSPACE`**:
 ```starlark
 maven_jar(
   name = "co_cookies_sdk",
-  artifact = "co.cookies.sdk.sdk-java:v1.2021r1-beta1",
-  sha256 = "104329b140bfccaaf77bf0aeff38922c84d8f700f6116e369f6bf2c4ab4ac33f",
+  artifact = "co.cookies.sdk.sdk-java:v1.2021r1-beta2",
+  sha256 = "de2dede6ac061f249d2f990eec37d2388a7ae212cd6e8cdf068a9d4c7f19fc63",
 )
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,15 @@ sourceCompatibility = 11
 targetCompatibility = 11
 
 dependencies {
-    api group: 'com.google.api', name: 'gax', version: '1.65.1'
-    api group: 'com.google.api', name: 'gax-grpc', version: '1.65.1'
-    api group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
-    api group: 'co.cookies.sdk', name: 'gapic-sdk-catalog-v1-java', version: '0.0.0-SNAPSHOT'
+    api group: 'com.google.api', name: 'gax', version: '1.66.0'
+    api group: 'com.google.api', name: 'gax-grpc', version: '1.66.0'
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.31'
-    implementation group: 'co.cookies.sdk.grpc', name: 'grpc-sdk-catalog-v1-java', version: '0.0.0-SNAPSHOT'
-    implementation group: 'co.cookies.sdk.proto', name: 'proto-sdk-catalog-v1-java', version: '0.0.0-SNAPSHOT'
+    api group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+    api group: 'co.cookies.sdk', name: 'gapic-sdk-catalog-v1-java', version: 'v1.2021r1alpha4'
+    api group: 'co.cookies.sdk.grpc', name: 'grpc-sdk-catalog-v1-java', version: 'v1.2021r1alpha4'
+    api group: 'co.cookies.sdk.proto', name: 'proto-sdk-catalog-v1-java', version: 'v1.2021r1alpha4'
+    api group: 'co.cookies.sdk', name: 'proto-catalog', version: 'v1.2021r1alpha4'
+    api group: 'co.cookies.sdk', name: 'proto-cookies', version: 'v1.2021r1alpha4'
     compileOnly group: 'com.google.auto.value', name: 'auto-value-annotations', version: '1.8.1'
     runtimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     annotationProcessor group: 'com.google.auto.value', name: 'auto-value', version: '1.8.1'
@@ -90,8 +92,12 @@ repositories {
         url "artifactregistry://us-maven.pkg.dev/cookies-co/sdk-java"
     }
     maven {
-        name "github"
-        url "https://maven.pkg.github.com/CookiesCo/sdk-java"
+        name = "github"
+        url = uri("https://maven.pkg.github.com/CookiesCo/sdk-java")
+        credentials {
+            username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
+            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
     }
     google()
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 group 'co.cookies.sdk'
 archivesBaseName = "sdk-java"
-version 'v1.2021r1-beta2'
+version 'v1.2021r1-beta3-SNAPSHOT'
 
 sourceCompatibility = 11
 targetCompatibility = 11

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 group 'co.cookies.sdk'
 archivesBaseName = "sdk-java"
-version 'v1.2021r1-beta2-SNAPSHOT'
+version 'v1.2021r1-beta2'
 
 sourceCompatibility = 11
 targetCompatibility = 11

--- a/release-notes/v1.2021r1-beta2.md
+++ b/release-notes/v1.2021r1-beta2.md
@@ -1,0 +1,15 @@
+
+## Cookies SDK for Java
+
+Version: `v1.2021r1-beta2`
+Date: Sun, Aug 15th 2021
+
+
+### Release Notes
+
+Bug fixes and general version upgrades:
+- Fix issue with `CatalogV1.sync` method
+- Make GAX + libs API dependencies
+- Upgrade GAX > `1.66.0`
+- Upgrade components > `v1.2021r1alpha4`
+

--- a/src/main/java/co/cookies/sdk/SDKUtil.java
+++ b/src/main/java/co/cookies/sdk/SDKUtil.java
@@ -245,11 +245,11 @@ public final class SDKUtil {
 
                     // convert to a stream via the provided transformer. response streams produced by the server are
                     // joined into a single stream.
-                    return Stream.iterate(
+                    return Stream.concat(Stream.of(item), Stream.iterate(
                         item,
                         (entry) -> iter.hasNext(),
                         (entry) -> iter.next()
-                    ).flatMap(transformer);
+                    )).flatMap(transformer);
                 }
 
                 // if we never have a next item, then it's an empty result stream.

--- a/src/test/java/co/cookies/sdk/catalog/v1/CatalogClientV1ProdTests.java
+++ b/src/test/java/co/cookies/sdk/catalog/v1/CatalogClientV1ProdTests.java
@@ -75,6 +75,8 @@ public class CatalogClientV1ProdTests {
             .addCtin("C033274")
             .addCtin("C033280")
             .addCtin("C033281")
+            .addCtin("C036809")
+            .addCtin("C999999")  // known not to exist
             .build()));
 
         var productStream = op.get(30, TimeUnit.SECONDS);
@@ -82,5 +84,8 @@ public class CatalogClientV1ProdTests {
 
         assertNotNull(products, "products response should not be null");
         assertFalse(products.isEmpty(), "products should not be empty");
+
+        // we should only find 4
+        assertEquals(4, products.size(), "should only find 4 of 5 matching products");
     }
 }


### PR DESCRIPTION
This changeset fixes a bug in `CatalogV1.sync`, wherein the first response stanza is dropped instead of being passed through to the invoking client.

- [x] Fix stream bug
- [x] Add passing production test for `sync`
- [x] Prep for version bump
- [x] Upgrade GAX > `1.66.0`
- [x] Upgrade component libs > `v1.2021r1alpha4`

Fixes and closes CookiesCo/sdk-java#7.
Fixes and closes CookiesCo/platform#1021.